### PR TITLE
RDKEMW-2203: image assembler tv us migration support

### DIFF
--- a/conf/rdke-config.inc
+++ b/conf/rdke-config.inc
@@ -29,3 +29,7 @@ BBMASK .= "|${RDKROOT}/rdke/common/meta-oss-reference/recipes-support/jansson/ja
 #RDKE-292 Bring size Optimization across all layers.
 OPTIMIZE_DEFAULT = "-Os"
 FULL_OPTIMIZATION = "${OPTIMIZE_DEFAULT} -pipe ${DEBUG_FLAGS}"
+
+#Removing fstackprotector and fortify source
+SECURITY_CFLAGS_remove = " -fstack-protector -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wno-error=format-security -Wno-error=unused-result"
+SECURITY_LDFLAGS_remove = " -fstack-protector"


### PR DESCRIPTION
Reason for change:
image assembler tv us migration support
cherry pick of https://github.com/rdk-e/rdke-common-config/pull/85

Test Procedure: None
Risks: Low