### PR TITLE
RDKEMW-3085: Add minidump support for rfcMgr

### DIFF
--- a/conf/rdke-breakpad-log.inc
+++ b/conf/rdke-breakpad-log.inc
@@ -37,6 +37,7 @@ BACKTRACE_DEPENDS:pn-cobaltlauncher = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-libloader-app = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-wpe-webkit = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-dcmd = " breakpad-wrapper"
+BACKTRACE_DEPENDS:pn-rfc = " breakpad-wrapper"
 
 BACKTRACE_LDFLAGS:pn-iarmbus = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-iarmmgrs = " -lbreakpadwrapper "
@@ -73,6 +74,7 @@ BACKTRACE_LDFLAGS:pn-libloader-app = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,
 BACKTRACE_LDFLAGS:pn-wpe-webkit = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-cobaltlauncher = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-dcmd = " -lbreakpadwrapper "
+BACKTRACE_LDFLAGS:pn-rfc = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 
 DEPENDS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_DEPENDS or ""}"
 LDFLAGS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_LDFLAGS or ""}"


### PR DESCRIPTION
Reason for change: Add minidump support for rfcMgr
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)