### PR TITLE
RDK-57319: Segmented global/system-wide profile

### DIFF
--- a/conf/rdke-distros.inc
+++ b/conf/rdke-distros.inc
@@ -1,5 +1,6 @@
 DISTRO_FEATURES:append = ' alsa'
 DISTRO_FEATURES:append = ' apparmor'
+DISTRO_FEATURES:append = ' apparmor_segmented_global'
 DISTRO_FEATURES:append = ' argp'
 DISTRO_FEATURES:append = ' aslr'
 DISTRO_FEATURES:append = ' bind'


### PR DESCRIPTION
Reason for change: Added DISTRO for apparmor-segmented-profile
Test Procedure: As mentioned in the ticket
Risks: Medium
Priority: P1