### PR TITLE
 RDKEMW-4416 [RDKE] Bring the Playready/Widevine bb files into meta-rdk-video

### DIFF
--- a/conf/rdke-repo-details.inc
+++ b/conf/rdke-repo-details.inc
@@ -1,3 +1,6 @@
 RDKE_GITHUB_PROTOCOL ?= "ssh"
 RDKE_GITHUB_SRC_URI_SUFFIX = "protocol=${RDKE_GITHUB_PROTOCOL};nobranch=1"
 
+# RDKM community config
+CMF_GIT_PROTOCOL ?= "https"
+CMF_GIT_SRC_URI_SUFFIX = "protocol=${CMF_GIT_PROTOCOL};nobranch=1"


### PR DESCRIPTION
Issues: RDKM github repo configuration is not present in rdke-common-config layer.

Reason for change:
1. We are moving Playready/Widevine bb files into meta-rdk-video layer.
2. Added the RDKM community specific repo configuration to build the Playready/Widevine bb files

Test Procedure: Verified the build and playback.

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com