### PR TITLE
RDKEMW-6999: Enable Breakpad for Airplay app

### DIFF
--- a/conf/rdke-breakpad-log.inc
+++ b/conf/rdke-breakpad-log.inc
@@ -41,6 +41,7 @@ BACKTRACE_DEPENDS:pn-rfc = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-nfrtool = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-AmazonPrimeVideoApp = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-amazonPrimeVideo = " breakpad-wrapper"
+BACKTRACE_DEPENDS:pn-skyAirplayPlugin = " breakpad-wrapper"
 
 BACKTRACE_LDFLAGS:pn-iarmbus = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-iarmmgrs = " -lbreakpadwrapper "
@@ -81,6 +82,7 @@ BACKTRACE_LDFLAGS:pn-rfc = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-neede
 BACKTRACE_LDFLAGS:pn-nfrtool = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-AmazonPrimeVideoApp = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-amazonPrimeVideo = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
+BACKTRACE_LDFLAGS:pn-skyAirplayPlugin = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 
 DEPENDS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_DEPENDS or ""}"
 LDFLAGS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_LDFLAGS or ""}"


### PR DESCRIPTION
Reason for change: activate breakpad for Airplay app.

Test Procedure: use breakpad
Risks: Low
Priority: P1