### PR TITLE
RDKEMW-7548: Breakpad for Netflix

### DIFF
--- a/conf/rdke-breakpad-log.inc
+++ b/conf/rdke-breakpad-log.inc
@@ -38,6 +38,7 @@ BACKTRACE_DEPENDS:pn-libloader-app = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-wpe-webkit = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-dcmd = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-rfc = " breakpad-wrapper"
+BACKTRACE_DEPENDS:pn-netflix-7.0.0 = " breakpad-wrapper"
 
 BACKTRACE_LDFLAGS:pn-iarmbus = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-iarmmgrs = " -lbreakpadwrapper "
@@ -75,6 +76,7 @@ BACKTRACE_LDFLAGS:pn-wpe-webkit = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--a
 BACKTRACE_LDFLAGS:pn-cobaltlauncher = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-dcmd = " -lbreakpadwrapper "
 BACKTRACE_LDFLAGS:pn-rfc = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
+BACKTRACE_LDFLAGS:pn-netflix-7.0.0 = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 
 DEPENDS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_DEPENDS or ""}"
 LDFLAGS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_LDFLAGS or ""}"


### PR DESCRIPTION
Reason for change:
 Breakpad for Netflix
Test Procedure: run pmap test on Netflix
Risks: Low