### PR TITLE
RDKEMW-7779: Breakpad for Netflix

### DIFF
--- a/conf/rdke-breakpad-log.inc
+++ b/conf/rdke-breakpad-log.inc
@@ -40,6 +40,7 @@ BACKTRACE_DEPENDS:pn-dcmd = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-rfc = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-nfrtool = " breakpad-wrapper"
 BACKTRACE_DEPENDS:pn-amazon-prime-library = " breakpad-wrapper"
+BACKTRACE_DEPENDS:pn-netflix-7.0.0 = " breakpad-wrapper"
 
 BACKTRACE_LDFLAGS:pn-iarmbus = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-iarmmgrs = " -lbreakpadwrapper "
@@ -80,6 +81,7 @@ BACKTRACE_LDFLAGS:pn-rfc = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-neede
 BACKTRACE_LDFLAGS:pn-nfrtool = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-amazon-prime-library = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 BACKTRACE_LDFLAGS:pn-wpeframework = "-Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed"
+BACKTRACE_LDFLAGS:pn-netflix-7.0.0 = " -Wl,--no-as-needed -lbreakpadwrapper -Wl,--as-needed "
 
 DEPENDS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_DEPENDS or ""}"
 LDFLAGS:append = " ${@LOG_BACKTRACE == "y" and BACKTRACE_LDFLAGS or ""}"


### PR DESCRIPTION
Reason for change:
 Breakpad support
Test Procedure: run pmap test on Netflix
Risks: Low